### PR TITLE
chore: remove renovate audit

### DIFF
--- a/.github/workflows/audit-renovate-config.yml
+++ b/.github/workflows/audit-renovate-config.yml
@@ -1,8 +1,0 @@
-name: Audit Renovate Config
-on: pull_request
-jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: coveo/public-actions/audit-renovate-config@main


### PR DESCRIPTION
We're no longer using this required workflow