### PR TITLE
chore: remove cloud intelligence from code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @coveo/dev-tooling @coveo/cloud-intelligence @coveo/r-d-security-defence
+* @coveo/dev-tooling @coveo/r-d-security-defence


### PR DESCRIPTION
We used to have a renovate workflow in here but it's gone and we no longer own renovate so we don't really belong here anymore.